### PR TITLE
Fixed race condition for size.getwidth() NPE

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -416,6 +416,10 @@ public class Camera1 extends CameraImpl {
     }
 
     private void adjustCameraParameters() {
+        adjustCameraParameters(0);
+    }
+
+    private void adjustCameraParameters(int current_try) {
         initResolutions();
 
         boolean invertPreviewSizes = mDisplayOrientation%180 != 0;
@@ -461,9 +465,14 @@ public class Camera1 extends CameraImpl {
         setFlash(mFlash);
 
         mCamera.setParameters(mCameraParameters);
-        if (have_to_readjust){
-            adjustCameraParameters();
+        if (have_to_readjust && current_try<100){
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             Log.d(TAG, "RE_ADJUST");
+            adjustCameraParameters(current_try+1);
         }
     }
 

--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -419,20 +419,41 @@ public class Camera1 extends CameraImpl {
         initResolutions();
 
         boolean invertPreviewSizes = mDisplayOrientation%180 != 0;
-        mPreview.setTruePreviewSize(
-                invertPreviewSizes? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
-                invertPreviewSizes? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
-        );
+        Camera.Parameters resolutionLess = mCamera.getParameters();
+        boolean have_to_readjust = false;
+        if (getPreviewResolution() != null) {
+            mPreview.setTruePreviewSize(
+                    invertPreviewSizes ? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
+                    invertPreviewSizes ? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
+            );
 
-        mCameraParameters.setPreviewSize(
-                getPreviewResolution().getWidth(),
-                getPreviewResolution().getHeight()
-        );
-
-        mCameraParameters.setPictureSize(
-                getCaptureResolution().getWidth(),
-                getCaptureResolution().getHeight()
-        );
+            mCameraParameters.setPreviewSize(
+                    getPreviewResolution().getWidth(),
+                    getPreviewResolution().getHeight()
+            );
+            try{
+                mCamera.setParameters(mCameraParameters);
+            }catch(Exception e){
+                e.printStackTrace();
+                mCameraParameters = resolutionLess; //some phones can't set parameters that camerakit has chosen, so fallback to defaults
+            }
+        }else{
+            have_to_readjust = true;
+        }
+        if (getCaptureResolution() != null) {
+            mCameraParameters.setPictureSize(
+                    getCaptureResolution().getWidth(),
+                    getCaptureResolution().getHeight()
+            );
+            try{
+                mCamera.setParameters(mCameraParameters);
+            }catch(Exception e){
+                e.printStackTrace();
+                mCameraParameters = resolutionLess; //some phones can't set parameters that camerakit has chosen, so fallback to defaults
+            }
+        }else{
+            have_to_readjust = true;
+        }
         int rotation = calculateCaptureRotation();
         mCameraParameters.setRotation(rotation);
 
@@ -440,6 +461,10 @@ public class Camera1 extends CameraImpl {
         setFlash(mFlash);
 
         mCamera.setParameters(mCameraParameters);
+        if (have_to_readjust){
+            adjustCameraParameters();
+            Log.d(TAG, "RE_ADJUST");
+        }
     }
 
     private void collectCameraProperties() {

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
@@ -295,12 +295,12 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
                 break;
         }
 
-        sWorkerHandler.post(new Runnable() {
+        sWorkerHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
                 mCameraImpl.start();
             }
-        });
+        }, 100);
     }
 
     public void stop() {


### PR DESCRIPTION
added check for null objects in adjustCameraParameters, added setParameters error handling and fallback if there is still a sync issue