### PR TITLE
Add ErrorListener + Don't crash when setting flash

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -456,45 +456,53 @@ public class Camera1 extends CameraImpl {
         });
     }
 
-    private void adjustCameraParameters(int current_try) {
+    private void adjustCameraParameters(int currentTry) {
         initResolutions();
 
         boolean invertPreviewSizes = mDisplayOrientation%180 != 0;
+
+        boolean haveToReadjust = false;
         Camera.Parameters resolutionLess = mCamera.getParameters();
-        boolean have_to_readjust = false;
+
         if (getPreviewResolution() != null) {
             mPreview.setTruePreviewSize(
-                    invertPreviewSizes ? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
-                    invertPreviewSizes ? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
+                invertPreviewSizes ? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
+                invertPreviewSizes ? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
             );
 
             mCameraParameters.setPreviewSize(
-                    getPreviewResolution().getWidth(),
-                    getPreviewResolution().getHeight()
+                getPreviewResolution().getWidth(),
+                getPreviewResolution().getHeight()
             );
-            try{
+
+            try {
                 mCamera.setParameters(mCameraParameters);
-            }catch(Exception e){
+            } catch (Exception e) {
                 notifyErrorListener(e);
-                mCameraParameters = resolutionLess; //some phones can't set parameters that camerakit has chosen, so fallback to defaults
+                // Some phones can't set parameters that camerakit has chosen, so fallback to defaults
+                mCameraParameters = resolutionLess;
             }
-        }else{
-            have_to_readjust = true;
+        } else {
+            haveToReadjust = true;
         }
+
         if (getCaptureResolution() != null) {
             mCameraParameters.setPictureSize(
-                    getCaptureResolution().getWidth(),
-                    getCaptureResolution().getHeight()
+                getCaptureResolution().getWidth(),
+                getCaptureResolution().getHeight()
             );
-            try{
+
+            try {
                 mCamera.setParameters(mCameraParameters);
-            }catch(Exception e){
+            } catch (Exception e) {
                 notifyErrorListener(e);
-                mCameraParameters = resolutionLess; //some phones can't set parameters that camerakit has chosen, so fallback to defaults
+                //Some phones can't set parameters that camerakit has chosen, so fallback to defaults
+                mCameraParameters = resolutionLess;
             }
-        }else{
-            have_to_readjust = true;
+        } else {
+            haveToReadjust = true;
         }
+
         int rotation = calculateCaptureRotation();
         mCameraParameters.setRotation(rotation);
 
@@ -502,14 +510,16 @@ public class Camera1 extends CameraImpl {
         setFlash(mFlash);
 
         mCamera.setParameters(mCameraParameters);
-        if (have_to_readjust && current_try<100){
+
+        if (haveToReadjust && currentTry < 100) {
             try {
                 Thread.sleep(1);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-            notifyErrorListener("adjustCameraParameters failed, try: " + current_try);
-            adjustCameraParameters(current_try+1);
+
+            notifyErrorListener("adjustCameraParameters failed, try: " + currentTry);
+            adjustCameraParameters(currentTry + 1);
         }
     }
 

--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -430,7 +430,7 @@ public class Camera1 extends CameraImpl {
         adjustCameraParameters(0);
     }
 
-    private void notifyErrorListener(@NonNull final String event) {
+    private void notifyErrorListener(@NonNull final String name, @NonNull final String details) {
         if (mErrorListener == null) {
             return;
         }
@@ -438,7 +438,7 @@ public class Camera1 extends CameraImpl {
         mainHandler.post(new Runnable() {
             @Override
             public void run() {
-                mErrorListener.onEvent(event);
+                mErrorListener.onEvent(name, details);
             }
         });
     }
@@ -507,7 +507,12 @@ public class Camera1 extends CameraImpl {
         mCameraParameters.setRotation(rotation);
 
         setFocus(mFocus);
-        setFlash(mFlash);
+
+        try {
+            setFlash(mFlash);
+        } catch (Exception e) {
+            notifyErrorListener("setFlash", e.getLocalizedMessage());
+        }
 
         mCamera.setParameters(mCameraParameters);
 
@@ -518,7 +523,7 @@ public class Camera1 extends CameraImpl {
                 e.printStackTrace();
             }
 
-            notifyErrorListener("adjustCameraParameters failed, try: " + currentTry);
+            notifyErrorListener("retryAdjustParam", "Failed, try: " + currentTry);
             adjustCameraParameters(currentTry + 1);
         }
     }

--- a/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
+++ b/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
@@ -232,6 +232,11 @@ class Camera2 extends CameraImpl {
         return mCamera != null;
     }
 
+    @Override
+    void setErrorListener(ErrorListener listener) {
+
+    }
+
     @Nullable
     @Override
     CameraProperties getCameraProperties() {

--- a/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
@@ -32,6 +32,8 @@ abstract class CameraImpl {
     abstract Size getPreviewResolution();
     abstract boolean isCameraOpened();
 
+    abstract void setErrorListener(ErrorListener listener);
+
     @Nullable
     abstract CameraProperties getCameraProperties();
 

--- a/camerakit/src/main/base/com/flurgle/camerakit/ErrorListener.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/ErrorListener.java
@@ -6,5 +6,5 @@ package com.flurgle.camerakit;
 
 public interface ErrorListener {
     void onError(Exception e);
-    void onEvent(String event);
+    void onEvent(String name, String details);
 }

--- a/camerakit/src/main/base/com/flurgle/camerakit/ErrorListener.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/ErrorListener.java
@@ -1,0 +1,10 @@
+package com.flurgle.camerakit;
+
+/**
+ * Created by Bruno Capezzali on 9/14/17.
+ */
+
+public interface ErrorListener {
+    void onError(Exception e);
+    void onEvent(String event);
+}

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
@@ -461,6 +461,10 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         }
     }
 
+    public void setErrorListener(ErrorListener listener) {
+        mCameraImpl.setErrorListener(listener);
+    }
+
     private class CameraListenerMiddleWare extends CameraListener {
 
         private CameraListener mCameraListener;

--- a/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
@@ -17,6 +18,7 @@ import android.widget.Toast;
 import com.flurgle.camerakit.CameraKit;
 import com.flurgle.camerakit.CameraListener;
 import com.flurgle.camerakit.CameraView;
+import com.flurgle.camerakit.ErrorListener;
 
 import java.io.File;
 
@@ -82,6 +84,17 @@ public class MainActivity extends AppCompatActivity implements View.OnLayoutChan
         });
 
         camera.addOnLayoutChangeListener(this);
+        camera.setErrorListener(new ErrorListener() {
+            @Override
+            public void onError(Exception e) {
+                Log.d("", e.getLocalizedMessage());
+            }
+
+            @Override
+            public void onEvent(String event) {
+                Log.d("", event);
+            }
+        });
 
         captureModeRadioGroup.setOnCheckedChangeListener(captureModeChangedListener);
         cropModeRadioGroup.setOnCheckedChangeListener(cropModeChangedListener);

--- a/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
@@ -91,8 +91,8 @@ public class MainActivity extends AppCompatActivity implements View.OnLayoutChan
             }
 
             @Override
-            public void onEvent(String event) {
-                Log.d("", event);
+            public void onEvent(String name, String details) {
+                Log.d("", name + " -> " + details);
             }
         });
 


### PR DESCRIPTION
Please review @AndrewGable 
cc @Expensify/mobile 

### This PR does
- Add an `ErrorListener` so that we can log when the camera has problems from our app too
- Style the code for the PR made by gasoline-joe
- Avoid to crash when setting the flash if that happens within `adjustCameraParameters`

### Tests
- Put a breakpoint in `MainActivity` lines 90 and 95
- Run the demo app
- Confirm the app doesn't crash
- Try to play with the demo app and confirm one of the breakpoint gets hit (it happens with the Galaxy S7 Edge)
